### PR TITLE
[KNIFE-334] Add an option to create DNS 'A' records in Rackspace Cloud DNS when a node is created

### DIFF
--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -116,7 +116,7 @@ class Chef
         if version_one?
           v1_public_ip(server)
         else
-          v2_public_ip(server)
+          v2_access_ip(server) ? v2_access_ip(server) : v2_public_ip(server)
         end
       end
 
@@ -165,6 +165,10 @@ class Chef
       def v2_private_ip(server)
         private_ips = server.addresses["private"]
         extract_ipv4_address(private_ips) if private_ips
+      end
+
+      def v2_access_ip(server)
+        server.accessIPv4 == nil ? "" : server.accessIPv4
       end
 
       def extract_ipv4_address(ip_addresses)

--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -88,14 +88,6 @@ class Chef
               :rackspace_endpoint => Chef::Config[:knife][:rackspace_endpoint] || config[:rackspace_endpoint]
             )
           end
-          @dnsconnection ||= begin
-            dnsconnection = Fog::DNS.new(
-              :provider => 'Rackspace',
-              :rackspace_api_key => Chef::Config[:knife][:rackspace_api_key],
-              :rackspace_username => (Chef::Config[:knife][:rackspace_username] || Chef::Config[:knife][:rackspace_api_username]),
-              :rackspace_auth_url => Chef::Config[:knife][:rackspace_api_auth_url] || config[:rackspace_api_auth_url]
-            )
-          end
         else
           @connection ||= begin
             connection = Fog::Compute.new(
@@ -106,14 +98,14 @@ class Chef
               :rackspace_auth_url => Chef::Config[:knife][:rackspace_api_auth_url] || config[:rackspace_api_auth_url]
             )
           end
-          @dnsconnection ||= begin
-            dnsconnection = Fog::DNS.new(
-              :provider => 'Rackspace',
-              :rackspace_api_key => Chef::Config[:knife][:rackspace_api_key],
-              :rackspace_username => (Chef::Config[:knife][:rackspace_username] || Chef::Config[:knife][:rackspace_api_username]),
-              :rackspace_auth_url => Chef::Config[:knife][:rackspace_api_auth_url] || config[:rackspace_api_auth_url]
-            )
-          end
+        end
+        @dnsconnection ||= begin
+          dnsconnection = Fog::DNS.new(
+            :provider => 'Rackspace',
+            :rackspace_api_key => Chef::Config[:knife][:rackspace_api_key],
+            :rackspace_username => (Chef::Config[:knife][:rackspace_username] || Chef::Config[:knife][:rackspace_api_username]),
+            :rackspace_auth_url => Chef::Config[:knife][:rackspace_api_auth_url] || config[:rackspace_api_auth_url]
+          )
         end
       end
 

--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -168,7 +168,7 @@ class Chef
       end
 
       def v2_access_ip(server)
-        server.accessIPv4 == nil ? "" : server.accessIPv4
+        server.access_ipv4_address == nil ? "" : server.access_ipv4_address
       end
 
       def extract_ipv4_address(ip_addresses)

--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -88,11 +88,27 @@ class Chef
               :rackspace_endpoint => Chef::Config[:knife][:rackspace_endpoint] || config[:rackspace_endpoint]
             )
           end
+          @dnsconnection ||= begin
+            dnsconnection = Fog::DNS.new(
+              :provider => 'Rackspace',
+              :rackspace_api_key => Chef::Config[:knife][:rackspace_api_key],
+              :rackspace_username => (Chef::Config[:knife][:rackspace_username] || Chef::Config[:knife][:rackspace_api_username]),
+              :rackspace_auth_url => Chef::Config[:knife][:rackspace_api_auth_url] || config[:rackspace_api_auth_url]
+            )
+          end
         else
           @connection ||= begin
             connection = Fog::Compute.new(
               :provider => 'Rackspace',
               :version => 'v1',
+              :rackspace_api_key => Chef::Config[:knife][:rackspace_api_key],
+              :rackspace_username => (Chef::Config[:knife][:rackspace_username] || Chef::Config[:knife][:rackspace_api_username]),
+              :rackspace_auth_url => Chef::Config[:knife][:rackspace_api_auth_url] || config[:rackspace_api_auth_url]
+            )
+          end
+          @dnsconnection ||= begin
+            dnsconnection = Fog::DNS.new(
+              :provider => 'Rackspace',
               :rackspace_api_key => Chef::Config[:knife][:rackspace_api_key],
               :rackspace_username => (Chef::Config[:knife][:rackspace_username] || Chef::Config[:knife][:rackspace_api_username]),
               :rackspace_auth_url => Chef::Config[:knife][:rackspace_api_auth_url] || config[:rackspace_api_auth_url]

--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -99,6 +99,18 @@ class Chef
             )
           end
         end
+      end
+
+      def dnsconnection
+        Chef::Log.debug("version #{Chef::Config[:knife][:rackspace_version]}") #config file
+        Chef::Log.debug("version #{config[:rackspace_version]}") #cli
+        Chef::Log.debug("rackspace_api_key #{Chef::Config[:knife][:rackspace_api_key]}")
+        Chef::Log.debug("rackspace_username #{Chef::Config[:knife][:rackspace_username]}")
+        Chef::Log.debug("rackspace_api_username #{Chef::Config[:knife][:rackspace_api_username]}")
+        Chef::Log.debug("rackspace_auth_url #{Chef::Config[:knife][:rackspace_auth_url]}")
+        Chef::Log.debug("rackspace_auth_url #{config[:rackspace_api_auth_url]}")
+        Chef::Log.debug("rackspace_endpoint #{Chef::Config[:knife][:rackspace_endpoint]}")
+        Chef::Log.debug("rackspace_endpoint #{config[:rackspace_endpoint]}")
         @dnsconnection ||= begin
           dnsconnection = Fog::DNS.new(
             :provider => 'Rackspace',

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -398,9 +398,9 @@ class Chef
         }
         bootstrap_for_node(server, bootstrap_ip_address).run
 
-        # Check to see if a DNS 'A' record has been requeested
+        # Check to see if a DNS 'A' record has been requested
         rackspace_add_dns_record = Chef::Config[:knife][:zone]
-        if rackspace_add_dns_record != ''
+        unless rackspace_add_dns_record.nil?
            # Add a DNS 'A' record for this node.
            add_dns_record(server)
         end

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -192,7 +192,6 @@ class Chef
 
         rackconnect_wait = Chef::Config[:knife][:rackconnect_wait] || config[:rackconnect_wait]
         rackspace_servicelevel_wait = Chef::Config[:knife][:rackspace_servicelevel_wait] || config[:rackspace_servicelevel_wait]
-        rackspace_add_dns_record = Chef::Config[:knife][:zone]
 
         server = connection.servers.create(
           :name => node_name,
@@ -280,6 +279,9 @@ class Chef
       end
 
       def bootstrap_for_node(server, bootstrap_ip_address)
+
+        rackspace_add_dns_record = Chef::Config[:knife][:zone]
+
         bootstrap = Chef::Knife::Bootstrap.new
         bootstrap.name_args = [bootstrap_ip_address]
         bootstrap.config[:run_list] = config[:run_list]

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -197,9 +197,9 @@ class Chef
             print "."; 
             Chef::Log.debug("#{progress}%")
             if Chef::Config[:knife][:rackconnect_wait]
-              Chef::Log.debug("rackconnect_automation_status: #{metadata.get('rackconnect_automation_status')}")
-              Chef::Log.debug("rax_service_level_automation: #{metadata.get('rax_service_level_automation')}")
-              ready? and metadata.get('rackconnect_automation_status') == 'DEPLOYED' and metadata.get('rax_service_level_automation') == 'Complete'
+              Chef::Log.debug("rackconnect_automation_status: #{metadata.all['rackconnect_automation_status')}"]
+              Chef::Log.debug("rax_service_level_automation: #{metadata.all['rax_service_level_automation')}"]
+              ready? and metadata.all['rackconnect_automation_status'] == 'DEPLOYED' and metadata.all['rax_service_level_automation'] == 'Complete'
             else
               ready?
             end
@@ -207,8 +207,8 @@ class Chef
         rescue Fog::Errors::TimeoutError
           ui.error('Timeout waiting for the server to be created')
           msg_pair('Progress', "#{server.progress}%")
-          msg_pair('rackconnect_automation_status', metadata.get('rackconnect_automation_status'))
-          msg_pair('rax_service_level_automation', metadata.get('rax_service_level_automation'))
+          msg_pair('rackconnect_automation_status', metadata.all['rackconnect_automation_status')]
+          msg_pair('rax_service_level_automation', metadata.all['rax_service_level_automation')]
           Chef::Application.fatal! 'Server didn\'t finish on time'
         end
 

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -189,14 +189,13 @@ class Chef
         msg_pair("Flavor", server.flavor.name)
         msg_pair("Image", server.image.name)
         msg_pair("Metadata", server.metadata)
-
-        print "\n#{ui.color("Waiting server", :magenta)}"
+        msg_pair("RackConnect", Chef::Config[:knife][:rackconnect_wait] ? 'yes', 'no')
 
         # wait for it to be ready to do stuff
-        server.wait_for { 
+        server.wait_for(1200) { 
           print "."; 
           if Chef::Config[:knife][:rackconnect_wait]
-            ready? and metadata['rackconnect_automation_status'] == 'DEPLOYED'
+            ready? and metadata['rackconnect_automation_status'] == 'DEPLOYED' and metadata['rax_service_level_automation'] == 'Complete'
           else
             ready?
           end

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -197,8 +197,8 @@ class Chef
             print "."; 
             Chef::Log.debug("#{progress}%")
             if Chef::Config[:knife][:rackconnect_wait]
-              Chef::Log.debug("rackconnect_automation_status: #{metadata.all['rackconnect_automation_status')}"]
-              Chef::Log.debug("rax_service_level_automation: #{metadata.all['rax_service_level_automation')}"]
+              Chef::Log.debug("rackconnect_automation_status: #{metadata.all['rackconnect_automation_status']}"]
+              Chef::Log.debug("rax_service_level_automation: #{metadata.all['rax_service_level_automation']}"]
               ready? and metadata.all['rackconnect_automation_status'] == 'DEPLOYED' and metadata.all['rax_service_level_automation'] == 'Complete'
             else
               ready?
@@ -207,8 +207,8 @@ class Chef
         rescue Fog::Errors::TimeoutError
           ui.error('Timeout waiting for the server to be created')
           msg_pair('Progress', "#{server.progress}%")
-          msg_pair('rackconnect_automation_status', server.metadata.all['rackconnect_automation_status')]
-          msg_pair('rax_service_level_automation', server.metadata.all['rax_service_level_automation')]
+          msg_pair('rackconnect_automation_status', server.metadata.all['rackconnect_automation_status']]
+          msg_pair('rax_service_level_automation', server.metadata.all['rax_service_level_automation']]
           Chef::Application.fatal! 'Server didn\'t finish on time'
         end
 

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -192,7 +192,7 @@ class Chef
         msg_pair("RackConnect", Chef::Config[:knife][:rackconnect_wait] ? 'yes' : 'no')
 
         # wait for it to be ready to do stuff
-        server.wait_for(1200) { 
+        server.wait_for(2400) { 
           print "."; 
           if Chef::Config[:knife][:rackconnect_wait]
             ready? and metadata['rackconnect_automation_status'] == 'DEPLOYED' and metadata['rax_service_level_automation'] == 'Complete'

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -192,6 +192,7 @@ class Chef
 
         rackconnect_wait = Chef::Config[:knife][:rackconnect_wait] || config[:rackconnect_wait]
         rackspace_servicelevel_wait = Chef::Config[:knife][:rackspace_servicelevel_wait] || config[:rackspace_servicelevel_wait]
+        rackspace_add_dns_record = Chef::Config[:knife][:zone]
 
         server = connection.servers.create(
           :name => node_name,

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -192,14 +192,21 @@ class Chef
         msg_pair("RackConnect", Chef::Config[:knife][:rackconnect_wait] ? 'yes' : 'no')
 
         # wait for it to be ready to do stuff
-        server.wait_for(2400) { 
-          print "."; 
-          if Chef::Config[:knife][:rackconnect_wait]
-            ready? and metadata['rackconnect_automation_status'] == 'DEPLOYED' and metadata['rax_service_level_automation'] == 'Complete'
-          else
-            ready?
-          end
-        }
+        begin
+          server.wait_for(2400) { 
+            print "."; 
+            if Chef::Config[:knife][:rackconnect_wait]
+              ready? and metadata['rackconnect_automation_status'] == 'DEPLOYED' and metadata['rax_service_level_automation'] == 'Complete'
+            else
+              ready?
+            end
+          }
+        rescue Fog::Errors::TimeoutError
+          ui.error('Timeout waiting for the server to be created')
+          msg_pair('Progress', "#{server.progress}%")
+          msg_pair('Metadata', server.metadata)
+        end
+
 
         puts("\n")
 

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -207,8 +207,8 @@ class Chef
         rescue Fog::Errors::TimeoutError
           ui.error('Timeout waiting for the server to be created')
           msg_pair('Progress', "#{server.progress}%")
-          msg_pair('rackconnect_automation_status', metadata.all['rackconnect_automation_status')]
-          msg_pair('rax_service_level_automation', metadata.all['rax_service_level_automation')]
+          msg_pair('rackconnect_automation_status', server.metadata.all['rackconnect_automation_status')]
+          msg_pair('rax_service_level_automation', server.metadata.all['rax_service_level_automation')]
           Chef::Application.fatal! 'Server didn\'t finish on time'
         end
 

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -189,7 +189,7 @@ class Chef
         msg_pair("Flavor", server.flavor.name)
         msg_pair("Image", server.image.name)
         msg_pair("Metadata", server.metadata)
-        msg_pair("RackConnect", Chef::Config[:knife][:rackconnect_wait] ? 'yes', 'no')
+        msg_pair("RackConnect", Chef::Config[:knife][:rackconnect_wait] ? 'yes' : 'no')
 
         # wait for it to be ready to do stuff
         server.wait_for(1200) { 

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -280,13 +280,20 @@ class Chef
       end
 
       def add_dns_record(server)
+
+        if version_one?
+          chef_node_name = config[:chef_node_name] || server.id
+        else
+          chef_node_name = server.name
+        end
+
         rackspace_add_dns_record = Chef::Config[:knife][:zone]
         if rackspace_add_dns_record != ''
-          printf "\nAdding DNS record for %s ...\n", bootstrap.config[:chef_node_name]
+          printf "\nAdding DNS record for %s ...\n", chef_node_name
           zone = dnsconnection.zones.find { |z| z.domain == Chef::Config[:knife][:zone] }
           record = zone.records.create(
             :value => public_ip(server),
-            :name  => "#{bootstrap.config[:chef_node_name]}.#{Chef::Config[:knife][:zone]}",
+            :name  => "#{chef_node_name}.#{Chef::Config[:knife][:zone]}",
             :type => 'A'
           )
         end

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -197,8 +197,8 @@ class Chef
             print "."; 
             Chef::Log.debug("#{progress}%")
             if Chef::Config[:knife][:rackconnect_wait]
-              Chef::Log.debug("rackconnect_automation_status: #{metadata.all['rackconnect_automation_status']}"]
-              Chef::Log.debug("rax_service_level_automation: #{metadata.all['rax_service_level_automation']}"]
+              Chef::Log.debug("rackconnect_automation_status: #{metadata.all['rackconnect_automation_status']}")
+              Chef::Log.debug("rax_service_level_automation: #{metadata.all['rax_service_level_automation']}")
               ready? and metadata.all['rackconnect_automation_status'] == 'DEPLOYED' and metadata.all['rax_service_level_automation'] == 'Complete'
             else
               ready?
@@ -207,8 +207,8 @@ class Chef
         rescue Fog::Errors::TimeoutError
           ui.error('Timeout waiting for the server to be created')
           msg_pair('Progress', "#{server.progress}%")
-          msg_pair('rackconnect_automation_status', server.metadata.all['rackconnect_automation_status']]
-          msg_pair('rax_service_level_automation', server.metadata.all['rax_service_level_automation']]
+          msg_pair('rackconnect_automation_status', server.metadata.all['rackconnect_automation_status'])
+          msg_pair('rax_service_level_automation', server.metadata.all['rax_service_level_automation'])
           Chef::Application.fatal! 'Server didn\'t finish on time'
         end
 

--- a/lib/knife-rackspace/version.rb
+++ b/lib/knife-rackspace/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Rackspace
-    VERSION = "0.6.3"
+    VERSION = "0.6.4"
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/KNIFE-334

This PR adds an option "--rackspace-add-dns-record" that will create an A record within Cloud DNS when a node is created.  This option takes a DNS zone name as a parameter and create an A record of <node name>.<zone name> that points to the public IP of the new node.   This PR is a continuation of the work in the previous PR I submitted:

https://github.com/opscode/knife-rackspace/pull/42

This new PR depends on the work in PR #42, which adds more intelligent determination of the correct public IP in RackConnect environments.