### PR TITLE
Mounting cloud block storage volumes, with unit tests. - Work in progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ Icon?
 
 *.swp
 *.swo
+
+# RVM .* files
+.ruby-gemset
+.ruby-version
+

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source "http://rubygems.org"
 
 group :development, :test do
   gem "knife-dsl", :git => 'git://github.com/maxlinc/knife-dsl.git', :branch => 'io_capture_fix'
+  gem 'debugger', :platforms => :mri_19
+  gem 'byebug', :platforms => [:mri_20, :mri_21, :mri_22]
 end
 
 # Specify your gem's dependencies in knife-rackspace.gemspec

--- a/README.rdoc
+++ b/README.rdoc
@@ -94,6 +94,8 @@ You may specify a custom network using the <tt>--network [LABEL_OR_ID]</tt> opti
 
 Note: If you are using one of the `performanceX-X` machines, you need to put `-f` or `--flavor` in quotes.
 
+You may create a Cloud Block Storage device by using the <tt>--volume-name NAME</tt> option. The device will default to a 100GB SATA device named /dev/xvdb. You can use the <tt>--volume-size</tt>, <tt>--volume-type</tt>, and <tt>--device-name</tt> options to modify these defaults. If no volume name is supplied, then no device will be created.
+
 === Windows
 
 Windows Servers require special treatment with the knife-rackspace gem.
@@ -135,6 +137,10 @@ Creates a new cloud network. Both the label and the CIDR are required parameters
 == knife rackspace network delete
 
 Deletes one or more specified networks by id. The network must be detached from all hosts before it is deleted.
+
+knife rackspace volume_type list
+
+Outputs a list of volume types available to the currently configured Rackspace Cloud account. A volume type identifies the type of storage created by the block storage API.
 
 = LICENSE:
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -138,7 +138,7 @@ Creates a new cloud network. Both the label and the CIDR are required parameters
 
 Deletes one or more specified networks by id. The network must be detached from all hosts before it is deleted.
 
-knife rackspace volume_type list
+== knife rackspace volume_type list
 
 Outputs a list of volume types available to the currently configured Rackspace Cloud account. A volume type identifies the type of storage created by the block storage API.
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -142,6 +142,10 @@ Deletes one or more specified networks by id. The network must be detached from 
 
 Outputs a list of volume types available to the currently configured Rackspace Cloud account. A volume type identifies the type of storage created by the block storage API.
 
+== knife rackspace cbs_volume list
+
+Outputs a list of cloud block storage volumes, their sizes (in GB) and the type of volume (SATA or SSD).
+
 = LICENSE:
 
 Author:: Adam Jacob (<adam@opscode.com>)

--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -109,7 +109,7 @@ class Chef
           Chef::Log.warn("Ignoring the rackspace_region parameter as it is only supported for Next Gen Cloud Servers (v2)")
         end
       end
-      
+
       def block_storage_connection
         Chef::Log.debug("setting up block storage connection")
         Chef::Log.debug("version #{Chef::Config[:knife][:rackspace_version]} (config)")
@@ -122,7 +122,7 @@ class Chef
         Chef::Log.debug("rackspace_auth_url #{auth_endpoint} (using)")
         Chef::Log.debug("rackspace_region #{Chef::Config[:knife][:rackspace_region]}")
         Chef::Log.debug("rackspace_region #{config[:rackspace_region]}")
-      
+
         if version_one?
           Chef::Log.debug("rackspace v1")
           block_storage_warning_for_v1
@@ -134,7 +134,7 @@ class Chef
           end
         end
       end
-      
+
       def connection_params(options={})
         unless locate_config_value(:rackspace_region)
           ui.error "Please specify region via the command line using the --rackspace-region switch or add a knife[:rackspace_region] = REGION to your knife file."
@@ -161,7 +161,7 @@ class Chef
 
         hash
       end
-      
+
       def block_storage_connection_params(options={})
         hash = options.merge({
           :rackspace_api_key => Chef::Config[:knife][:rackspace_api_key],
@@ -169,7 +169,7 @@ class Chef
           :rackspace_auth_url => auth_endpoint,
           :rackspace_region => locate_config_value(:rackspace_region)
         })
-      
+
         hash[:connection_options] ||= {}
         Chef::Log.debug("https_proxy #{ Chef::Config[:https_proxy] || "<not specified>"} (config)")
         Chef::Log.debug("http_proxy #{ Chef::Config[:http_proxy] || "<not specified>"} (config)")
@@ -179,10 +179,10 @@ class Chef
         Chef::Log.debug("using proxy #{hash[:connection_options][:proxy] || "<none>"} (config)")
         Chef::Log.debug("ssl_verify_peer #{Chef::Config[:knife].has_key?(:ssl_verify_peer) ? Chef::Config[:knife][:ssl_verify_peer] : "<not specified>"} (config)")
         hash[:connection_options][:ssl_verify_peer] = Chef::Config[:knife][:ssl_verify_peer] if Chef::Config[:knife].has_key?(:ssl_verify_peer)
-      
+
         hash
       end
-      
+
       def auth_endpoint
         url = locate_config_value(:rackspace_auth_url)
         return url if url

--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -184,7 +184,7 @@ class Chef
       end
 
       def msg_pair(label, value, color=:cyan)
-        if value && !value.to_s.empty?
+        if value && !value.to_s.empty? && !testing?
           puts "#{ui.color(label, color)}: #{value}"
         end
       end
@@ -227,7 +227,7 @@ class Chef
       end
 
       def v1_public_ip(server)
-          server.public_ip_address == nil ? "" : server.public_ip_address
+        server.public_ip_address == nil ? "" : server.public_ip_address
       end
 
       def v1_private_ip(server)
@@ -236,6 +236,7 @@ class Chef
 
       def v2_ip_address(server, network)
         network_ips = server.addresses[network]
+
         extract_ipv4_address(network_ips) if network_ips
       end
 
@@ -247,6 +248,17 @@ class Chef
         address = ip_addresses.select { |ip| ip["version"] == 4 }.first
         address ? address["addr"] : ""
       end
+
+      def testing?
+        defined?(TESTING) && TESTING
+      end
+      private :testing?
+
+      def stdout(value)
+        puts value unless testing?
+      end
+      private :stdout
+
     end
   end
 end

--- a/lib/chef/knife/rackspace_cbs_volume_list.rb
+++ b/lib/chef/knife/rackspace_cbs_volume_list.rb
@@ -1,0 +1,48 @@
+#
+# Author:: Carlos Diaz (<crdiaz324@gmail.com>)
+# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife/rackspace_base'
+
+class Chef
+  class Knife
+    class RackspaceCbsVolumeList < Knife
+
+      include Knife::RackspaceBase
+
+      banner "knife rackspace cbs_volume list"
+
+      def run
+        cbs_volume_list = [
+          ui.color('ID', :bold),
+          ui.color('Name', :bold),
+          ui.color('Volume Size', :bold),
+          ui.color('Volume Type', :bold)
+        ]
+
+        block_storage_connection.volumes.sort_by(&:display_name).each do |volume|
+          cbs_volume_list << volume.id.to_s
+          cbs_volume_list << volume.display_name
+          cbs_volume_list << volume.size.to_s
+          cbs_volume_list << volume.volume_type
+        end
+
+        puts ui.list(cbs_volume_list, :uneven_columns_across, 4)
+      end
+    end
+  end
+end

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -236,6 +236,11 @@ class Chef
         :description => "A file containing the secret key to use to encrypt data bag item values",
         :proc => Proc.new { |sf| Chef::Config[:knife][:secret_file] = sf }
 
+      option :volume_id,
+        :long => "--volume-id UUID",
+        :description => "UUID of a Cloud Block Storage volume to boot the server from",
+        :proc => Proc.new { |vol_id| Chef::Config[:knife][:cbs_volume_id] = vol_id.to_s }
+
       option :volume_name,
         :long => "--volume-name NAME",
         :description => "Create a Cloud Block Storage device with the specified name",
@@ -380,7 +385,7 @@ class Chef
         rackconnect_wait = Chef::Config[:knife][:rackconnect_wait] || config[:rackconnect_wait]
         rackspace_servicelevel_wait = Chef::Config[:knife][:rackspace_servicelevel_wait] || config[:rackspace_servicelevel_wait]
 
-        server = connection.servers.new(
+        server_opts = {
           :name => node_name,
           :image_id => Chef::Config[:knife][:image],
           :flavor_id => locate_config_value(:flavor),
@@ -390,7 +395,22 @@ class Chef
           :config_drive => locate_config_value(:rackspace_config_drive) || false,
           :personality => files,
           :key_name => Chef::Config[:knife][:rackspace_ssh_keypair]
-        )
+        }.tap do |opts|
+          if Chef::Config[:knife][:cbs_volume_id] # boot from specified volume
+            stdout("\n#{ui.color("Boot from existing Cloud Block Storage volume", :magenta)}")
+            msg_pair("CBS Volume ID:", Chef::Config[:knife][:cbs_volume_id])
+            opts[:image_id] = ''
+            opts[:boot_volume_id] = Chef::Config[:knife][:cbs_volume_id]
+          elsif Chef::Config[:knife][:volume_name] && Chef::Config[:knife][:image]  # create a new volume for the specified image with the specified name
+            stdout("\n#{ui.color("Boot from new Block Storage volume", :magenta)}")
+            msg_pair("CBS Source Image:", Chef::Config[:knife][:image])
+            opts[:image_id] = ''
+            opts[:boot_volume_id] = create_cbs_volume.id
+          end
+
+        end
+
+        server = connection.servers.new(server_opts)
 
         if version_one?
           server.save
@@ -402,7 +422,7 @@ class Chef
         msg_pair("Host ID", server.host_id)
         msg_pair("Name", server.name)
         msg_pair("Flavor", server.flavor.name)
-        msg_pair("Image", server.image.name)
+        msg_pair("Image", (server.image && server.image.name) || 'None')
         msg_pair("Metadata", server.metadata.all)
         msg_pair("ConfigDrive", server.config_drive)
         msg_pair("UserData", Chef::Config[:knife][:rackspace_user_data])
@@ -415,7 +435,7 @@ class Chef
         # wait for it to be ready to do stuff
         begin
           server.wait_for(Integer(locate_config_value(:server_create_timeout))) {
-            stdout ".";
+            print ".";
             Chef::Log.debug("#{progress}%")
             if rackconnect_wait and rackspace_servicelevel_wait
               Chef::Log.debug("rackconnect_automation_status: #{metadata.all['rackconnect_automation_status']}")
@@ -453,21 +473,11 @@ class Chef
         msg_pair("Password", server.password)
         msg_pair("Metadata", server.metadata.all)
 
-        if Chef::Config[:knife][:volume_name]
-          Chef::Log.debug("Setting up block storage")
-          Chef::Log.debug("Volume size: #{Chef::Config[:knife][:volume_size]}")
-          Chef::Log.debug("Volume name: #{Chef::Config[:knife][:volume_name]}")
-          Chef::Log.debug("Volume type: #{Chef::Config[:knife][:volume_type]}")
-          Chef::Log.debug("Device name: #{Chef::Config[:knife][:device_name]}")
-          volume_size = (Chef::Config[:knife][:volume_size] || 100).to_i
-          volume_name = Chef::Config[:knife][:volume_name]
-          volume_type_name = Chef::Config[:knife][:volume_type] || 'SATA'
-          new_volume = block_storage_connection.volumes.create(:size => volume_size, :display_name => volume_name, :volume_type => volume_type_name)
-          stdout("\n#{ui.color("Waiting storage", :magenta)}")
-
-          new_volume.wait_for(Integer(locate_config_value(:server_create_timeout))) { stdout "."; ready? }
-
-          server.attach_volume new_volume.id, (Chef::Config[:knife][:device_name] || '/dev/xvdb')
+        if Chef::Config[:knife][:volume_name] && !server_opts[:boot_volume_id]
+          Chef::Log.debug("Attaching Cloud Block Storage Volume:")
+          device_name = (Chef::Config[:knife][:device_name] || '/dev/xvdb')
+          Chef::Log.debug("Device name: #{device_name}")
+          server.attach_volume create_cbs_volume.id, device_name
         end
 
         bootstrap_ip_address = ip_address(server, config[:bootstrap_network])
@@ -495,7 +505,7 @@ class Chef
         msg_pair("Host ID", server.host_id)
         msg_pair("Name", server.name)
         msg_pair("Flavor", server.flavor.name)
-        msg_pair("Image", server.image.name)
+        msg_pair("Image", (server.image && server.image.name) || 'None')
         msg_pair("Metadata", server.metadata)
         msg_pair("Public DNS Name", public_dns_name(server))
         msg_pair("Public IP Address", ip_address(server, 'public'))
@@ -517,6 +527,27 @@ class Chef
           exit 1
         end
         content
+      end
+
+      def create_cbs_volume
+        Chef::Log.debug("Creating new cloud block storage volume")
+        Chef::Log.debug("Volume size: #{Chef::Config[:knife][:volume_size]}")
+        Chef::Log.debug("Volume name: #{Chef::Config[:knife][:volume_name]}")
+        Chef::Log.debug("Volume type: #{Chef::Config[:knife][:volume_type]}")
+        volume_size = (Chef::Config[:knife][:volume_size] || 100).to_i
+        volume_name = Chef::Config[:knife][:volume_name]
+        volume_type_name = Chef::Config[:knife][:volume_type] || 'SATA'
+        volume_opts = {size: volume_size, display_name: volume_name, volume_type: volume_type_name}
+        # if a knife image was specified, we're going to create this volume from that image.
+        # otherwise it will be a bare volume
+        volume_opts[:image_id] = Chef::Config[:knife][:image] if Chef::Config[:knife][:image]
+        new_volume = block_storage_connection.volumes.create(volume_opts)
+        stdout("\n#{ui.color("Waiting for Cloud Block Storage:", :magenta)}")
+
+        new_volume.wait_for(Integer(locate_config_value(:server_create_timeout))) { print "."; ready? }
+        stdout("\n#{ui.color("Cloud Block Storage volume created and available", :magenta)}")
+        msg_pair("Cloud Block Storage Volume Id:", new_volume.id)
+        new_volume
       end
 
       def bootstrap_for_node(server, bootstrap_ip_address)

--- a/lib/chef/knife/rackspace_server_delete.rb
+++ b/lib/chef/knife/rackspace_server_delete.rb
@@ -66,7 +66,7 @@ class Chef
             msg_pair("Host ID", server.host_id)
             msg_pair("Name", server.name)
             msg_pair("Flavor", server.flavor.name)
-            msg_pair("Image", server.image.name)
+            msg_pair("Image", (server.image && server.image.name) || 'None')
             msg_pair("Public IP Address", ip_address(server, 'public'))
             msg_pair("Private IP Address", ip_address(server, 'private'))
 

--- a/lib/chef/knife/rackspace_volume_type_list.rb
+++ b/lib/chef/knife/rackspace_volume_type_list.rb
@@ -1,0 +1,44 @@
+#
+# Author:: Mike Gunderloy (<MikeG1@larkfarm.com>)
+# Copyright:: Copyright (c) 2013 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/knife/rackspace_base'
+
+class Chef
+  class Knife
+    class RackspaceVolumeTypeList < Knife
+
+      include Knife::RackspaceBase
+
+      banner "knife rackspace volume_type list (options)"
+
+      def run
+        volume_type_list = [
+          ui.color('ID', :bold),
+          ui.color('Name', :bold)
+        ]
+
+        block_storage_connection.volume_types.sort_by(&:name).each do |volume_type|
+          volume_type_list << volume_type.id.to_s
+          volume_type_list << volume_type.name
+        end
+
+        puts ui.list(volume_type_list, :uneven_columns_across, 2)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,5 +12,22 @@ end
 
 RSpec.configure do |config|
   config.color = true
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+
+  config.before(:example) do
+    # reset any Chef::Config vars so we don't get test order dependencies
+    Chef::Config[:knife] = {}
+  end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,14 @@
 $:.unshift File.expand_path('../../lib', __FILE__)
 require 'chef/knife/bootstrap'
 require 'chef/knife/rackspace_base'
+
+if RUBY_VERSION < '2.0'
+  require 'debugger'
+else
+  require 'byebug'
+end
+
+RSpec.configure do |config|
+  config.color = true
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@ $:.unshift File.expand_path('../../lib', __FILE__)
 require 'chef/knife/bootstrap'
 require 'chef/knife/rackspace_base'
 
+TESTING = true
+
 if RUBY_VERSION < '2.0'
   require 'debugger'
 else

--- a/spec/unit/rackspace_base_spec.rb
+++ b/spec/unit/rackspace_base_spec.rb
@@ -36,6 +36,22 @@ describe Chef::Knife::RackspaceBase do
     end
   end
 
+  describe '#connection' do
+    let(:ui) { double(Chef::Knife::UI) }
+
+    before do
+      allow(Chef::Knife::UI).to receive(:new).and_return(ui)
+    end
+
+    it 'raises a ui error and exits unless rackspace region has been set' do
+      expect(ui).to receive(:error).with(/Please specify region/)
+
+      Chef::Config[:knife][:rackspace_region] = nil
+
+      expect{ tester.connection }.to raise_error(SystemExit)
+    end
+  end
+
   describe '#block_storage_connection' do
     let(:fog_connection) { double(Fog::Rackspace::BlockStorage) }
 
@@ -45,4 +61,5 @@ describe Chef::Knife::RackspaceBase do
       expect(tester.block_storage_connection).to eq(fog_connection)
     end
   end
+
 end

--- a/spec/unit/rackspace_base_spec.rb
+++ b/spec/unit/rackspace_base_spec.rb
@@ -38,9 +38,12 @@ describe Chef::Knife::RackspaceBase do
 
   describe '#connection' do
     let(:ui) { double(Chef::Knife::UI) }
+    let(:fog_connection) { double(Fog::Compute) }
 
     before do
       allow(Chef::Knife::UI).to receive(:new).and_return(ui)
+      allow(Fog::Compute).to receive(:new).and_return(fog_connection)
+      Chef::Config[:knife][:rackspace_region] = :ord
     end
 
     it 'raises a ui error and exits unless rackspace region has been set' do
@@ -50,12 +53,150 @@ describe Chef::Knife::RackspaceBase do
 
       expect{ tester.connection }.to raise_error(SystemExit)
     end
+
+    context 'when rackspace api is version one' do
+      it 'returns a fog connection initialized with a version 1 option' do
+        Chef::Config[:knife][:rackspace_version] = 'v1'
+
+        expect(Fog::Compute).to receive(:new)
+          .with(hash_including(version: 'v1'))
+          .and_return(fog_connection)
+
+        expect(tester.connection).to eq(fog_connection)
+      end
+    end
+
+    context 'when rackspace api is version two' do
+      it 'returns a fog connection initialized with a version 2 option' do
+        Chef::Config[:knife][:rackspace_version] = 'v2'
+
+        expect(Fog::Compute).to receive(:new)
+          .with(hash_including(version: 'v2'))
+          .and_return(fog_connection)
+
+        expect(tester.connection).to eq(fog_connection)
+      end
+    end
+
+    it 'sets provider option to "Rackspace"' do
+      expect(Fog::Compute).to receive(:new)
+        .with(hash_including(provider: 'Rackspace'))
+
+      tester.connection
+    end
+
+    it 'sets rackspace api key option to currently configured api key' do
+      api_key = 'test_key'
+      Chef::Config[:knife][:rackspace_api_key] = api_key
+
+      expect(Fog::Compute).to receive(:new)
+        .with(hash_including(rackspace_api_key: api_key))
+
+      tester.connection
+    end
+
+    context 'when chef is configured with rackspace username' do
+      it 'sets rackspace username option to chef rackspace username' do
+        username = 'test_username'
+        Chef::Config[:knife][:rackspace_username] = username
+
+        expect(Fog::Compute).to receive(:new)
+          .with(hash_including(rackspace_username: username))
+
+        tester.connection
+      end
+    end
+
+    context 'when chef is not configured with a rackspace username' do
+      it 'sets rackspace username option to chef racspace api_username' do
+        api_username = 'test_api_username'
+        Chef::Config[:knife][:rackspace_username] = nil
+        Chef::Config[:knife][:rackspace_api_username] = api_username
+
+        expect(Fog::Compute).to receive(:new)
+          .with(hash_including(rackspace_username: api_username))
+
+        tester.connection
+      end
+    end
+
+    it 'sets rackspace auth url option to correct auth endpoint' do
+      test_url = "http://test-url.com"
+      Chef::Config[:knife][:rackspace_auth_url] = test_url
+
+      expect(Fog::Compute).to receive(:new)
+        .with(hash_including(rackspace_auth_url: test_url))
+
+      tester.connection
+    end
+
+    it 'sets rackspace region option to configured rackspace region' do
+      test_region = :lon
+      Chef::Config[:knife][:rackspace_region] = test_region
+
+      expect(Fog::Compute).to receive(:new)
+        .with(hash_including(rackspace_region: test_region))
+
+      tester.connection
+    end
+
+    context 'when chef config has an https proxy' do
+      it 'sets the proxy connection option to the https proxy value' do
+        https_proxy = 'test_https_proxy'
+        Chef::Config[:https_proxy] = https_proxy
+
+        expect(Fog::Compute).to receive(:new)
+          .with(hash_including(connection_options: hash_including({proxy: https_proxy})))
+
+        tester.connection
+      end
+    end
+
+    context 'when chef config has an http proxy' do
+      it 'sets the proxy connection option to the http proxy value' do
+        http_proxy = 'test_http_proxy'
+        Chef::Config[:https_proxy] = nil
+        Chef::Config[:http_proxy] = http_proxy
+
+        expect(Fog::Compute).to receive(:new)
+          .with(hash_including(connection_options: hash_including({proxy: http_proxy})))
+
+        tester.connection
+      end
+    end
+
+    context 'when chef config has both an https and an http proxy' do
+      it 'sets the proxy connection option to the https proxy value' do
+        https_proxy = 'test_https_proxy'
+        http_proxy = 'test_http_proxy'
+        Chef::Config[:https_proxy] = https_proxy
+        Chef::Config[:http_proxy] = http_proxy
+
+        expect(Fog::Compute).to receive(:new)
+          .with(hash_including(connection_options: hash_including({proxy: https_proxy})))
+
+        tester.connection
+      end
+    end
+
+    it 'sets the ssl verify peer connection option if it is configured' do
+      ssl_verify_peer = 'test_verify_peer'
+      Chef::Config[:knife][:ssl_verify_peer] = ssl_verify_peer
+
+      expect(Fog::Compute).to receive(:new)
+        .with(hash_including(connection_options: hash_including({ssl_verify_peer: ssl_verify_peer})))
+
+      tester.connection
+    end
+
   end
 
   describe '#block_storage_connection' do
     let(:fog_connection) { double(Fog::Rackspace::BlockStorage) }
 
     it 'returns a Fog block storage connection initialized with block storage connection params' do
+      Chef::Config[:knife][:rackspace_version] = 'v2'
+      Chef::Config[:knife][:rackspace_region] = :ord
       expect(Fog::Rackspace::BlockStorage).to receive(:new).and_return(fog_connection)
 
       expect(tester.block_storage_connection).to eq(fog_connection)

--- a/spec/unit/rackspace_base_spec.rb
+++ b/spec/unit/rackspace_base_spec.rb
@@ -7,32 +7,42 @@ class RackspaceBaseTester < Chef::Knife
   include Chef::Knife::RackspaceBase
 end
 
-describe "auth_endpoint" do
-  it "should select the custom endpoint if specified" do
-    tester = RackspaceBaseTester.new
+describe Chef::Knife::RackspaceBase do
+  let(:tester) { RackspaceBaseTester.new }
 
-    test_url = "http://test-url.com"
-    Chef::Config[:knife][:rackspace_auth_url] = test_url
-    Chef::Config[:knife][:rackspace_region] = :ord
+  describe "auth_endpoint" do
+    it "should select the custom endpoint if specified" do
+      test_url = "http://test-url.com"
+      Chef::Config[:knife][:rackspace_auth_url] = test_url
+      Chef::Config[:knife][:rackspace_region] = :ord
 
-    expect(tester.auth_endpoint).to eq(test_url)
-  end
+      expect(tester.auth_endpoint).to eq(test_url)
+    end
 
-  [:dfw, :ord, :syd].each do |region|
-    it "should pick the US endpoint if the region is #{region}" do
-      tester = RackspaceBaseTester.new
+    [:dfw, :ord, :syd].each do |region|
+      it "should pick the US endpoint if the region is #{region}" do
+        Chef::Config[:knife][:rackspace_auth_url] = nil
+        Chef::Config[:knife][:rackspace_region] = region
+
+        expect(tester.auth_endpoint).to eq(::Fog::Rackspace::US_AUTH_ENDPOINT)
+      end
+    end
+
+    it "should pick the UK end point if the region is :lon" do
       Chef::Config[:knife][:rackspace_auth_url] = nil
-      Chef::Config[:knife][:rackspace_region] = region
+      Chef::Config[:knife][:rackspace_region] = 'lon'
 
-      expect(tester.auth_endpoint).to eq(::Fog::Rackspace::US_AUTH_ENDPOINT)
+      expect(tester.auth_endpoint).to eq(::Fog::Rackspace::UK_AUTH_ENDPOINT)
     end
   end
 
-  it "should pick the UK end point if the region is :lon" do
-    tester = RackspaceBaseTester.new
-    Chef::Config[:knife][:rackspace_auth_url] = nil
-    Chef::Config[:knife][:rackspace_region] = 'lon'
+  describe '#block_storage_connection' do
+    let(:fog_connection) { double(Fog::Rackspace::BlockStorage) }
 
-    expect(tester.auth_endpoint).to eq(::Fog::Rackspace::UK_AUTH_ENDPOINT)
+    it 'returns a Fog block storage connection initialized with block storage connection params' do
+      expect(Fog::Rackspace::BlockStorage).to receive(:new).and_return(fog_connection)
+
+      expect(tester.block_storage_connection).to eq(fog_connection)
+    end
   end
 end

--- a/spec/unit/rackspace_base_spec.rb
+++ b/spec/unit/rackspace_base_spec.rb
@@ -15,7 +15,7 @@ describe "auth_endpoint" do
     Chef::Config[:knife][:rackspace_auth_url] = test_url
     Chef::Config[:knife][:rackspace_region] = :ord
 
-    tester.auth_endpoint.should == test_url
+    expect(tester.auth_endpoint).to eq(test_url)
   end
 
   [:dfw, :ord, :syd].each do |region|
@@ -24,7 +24,7 @@ describe "auth_endpoint" do
       Chef::Config[:knife][:rackspace_auth_url] = nil
       Chef::Config[:knife][:rackspace_region] = region
 
-      tester.auth_endpoint.should == ::Fog::Rackspace::US_AUTH_ENDPOINT
+      expect(tester.auth_endpoint).to eq(::Fog::Rackspace::US_AUTH_ENDPOINT)
     end
   end
 
@@ -33,6 +33,6 @@ describe "auth_endpoint" do
     Chef::Config[:knife][:rackspace_auth_url] = nil
     Chef::Config[:knife][:rackspace_region] = 'lon'
 
-    tester.auth_endpoint.should == ::Fog::Rackspace::UK_AUTH_ENDPOINT
+    expect(tester.auth_endpoint).to eq(::Fog::Rackspace::UK_AUTH_ENDPOINT)
   end
 end

--- a/spec/unit/rackspace_server_create_spec.rb
+++ b/spec/unit/rackspace_server_create_spec.rb
@@ -225,6 +225,8 @@ describe Chef::Knife::RackspaceServerCreate do
 
         context 'when a device name is specified' do
           it 'attaches the volume to the specified device name' do
+            Chef::Config[:knife][:image] = nil
+
             device_name = '/dev/xbdc'
 
             Chef::Config[:knife][:device_name] = device_name
@@ -238,6 +240,8 @@ describe Chef::Knife::RackspaceServerCreate do
 
         context 'when no device name is specified' do
           it 'attaches the bolume to /dev/xvdb' do
+            Chef::Config[:knife][:image] = nil
+
             expect(server).to receive(:attach_volume)
               .with(volume.id, '/dev/xvdb')
 

--- a/spec/unit/rackspace_server_create_spec.rb
+++ b/spec/unit/rackspace_server_create_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+require 'chef/knife'
+require 'chef/knife/rackspace_server_create'
+
+describe Chef::Knife::RackspaceServerCreate do
+  let(:creator) { Chef::Knife::RackspaceServerCreate.new }
+  let(:ui) { double(Chef::Knife::UI, error: nil) }
+  let(:server_id) { rand(1000) }
+  let(:image) {  double('image', name: 'test_image') }
+  let(:flavor) { double('flavor', name: 'test flavor name') }
+  let(:metadata) { double('metadata', all: {}) }
+  let(:ip_address) { '10.0.0.0' }
+  let(:addresses) { { "public" => [{"version" => 4, "addr" => ip_address}] } }
+
+  let(:server) { double('server instance', save: true, id: server_id, host_id: 'test host id', name: 'test name',
+                          flavor: flavor, image: image, metadata: metadata, config_drive: '', wait_for: true,
+                          access_ipv4_address: ip_address, addresses: addresses, password: 'test password') }
+  let(:servers) { double('servers resource', new: server) }
+  let(:fog_compute_connection) { double(Fog::Compute, servers: servers) }
+
+  describe '#run' do
+    before do
+      allow_any_instance_of(Chef::Knife::Bootstrap).to receive(:run)
+      allow_any_instance_of(Chef::Knife::RackspaceServerCreate).to receive(:tcp_test_ssh).and_return(true)
+
+      allow(ui).to receive(:color) { |label| label }
+      allow(Chef::Knife::UI).to receive(:new).and_return(ui)
+      allow(Fog::Compute).to receive(:new).and_return(fog_compute_connection)
+      Chef::Config[:knife][:server_create_timeout] = 1200
+      allow(fog_compute_connection).to receive_message_chain('networks.all').and_return([])
+    end
+
+    it 'raises a ui error and exits unless image option has been set' do
+      expect(ui).to receive(:error).with(/You have not provided.*image/)
+
+      Chef::Config[:knife][:image] = nil
+
+      expect{ creator.run }.to raise_error(SystemExit)
+    end
+
+    it 'creates a new server instance and tries to save it' do
+      Chef::Config[:knife][:image] = image.name
+
+      expect(fog_compute_connection).to receive(:servers).and_return(servers)
+      expect(servers).to receive(:new).and_return(server)
+      expect(server).to receive(:save)
+
+      creator.run
+    end
+
+  end
+
+end


### PR DESCRIPTION
I also need support for spinning up compute instances using block storage volumes, so I've forked off the PR that @crdiaz324 started last November. (https://github.com/chef/knife-rackspace/pull/90)   I've added what I hope will be some acceptable unit tests.  Once I had test coverage for both the existing fog compute connection and block storage connection logic, I did a little refactoring (commit     2998bd2) to clean up some duplicated code.

It'd be great if I can get some feedback from the maintainers.  Are these the types of unit tests you needed to see in order to merge in this functionality?  Do you need tests for the list views as well?  Any issues with the spec syntax or style?

I don't know if this gem needs to support 1.9.3 as well as ruby 2.0+  Trying to bundle using 1.9.3 fails because of an ohai dependency.  If you want to still support 1.9.3 it may mean locking ohai to a particular version number.

If maintainers are ok with the unit test approach so far, I'll continue to flesh out the tests some more.  I was planning to next extract the block storage volume creation to a separate class, so that I can choose to create a block storage volume without attaching it to a server instance, and to be able to boot an instance from an existing volume.
