### PR TITLE
Change config lookup so CLI options override knife config

### DIFF
--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -145,7 +145,7 @@ class Chef
 
       def locate_config_value(key)
         key = key.to_sym
-        Chef::Config[:knife][key] || config[key]
+        config[key] || Chef::Config[:knife][key]
       end
 
       def msg_pair(label, value, color=:cyan)

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -357,7 +357,7 @@ class Chef
 
         server = connection.servers.new(
           :name => node_name,
-          :image_id => Chef::Config[:knife][:image],
+          :image_id => locate_config_value(:image),
           :flavor_id => locate_config_value(:flavor),
           :metadata => Chef::Config[:knife][:rackspace_metadata],
           :disk_config => Chef::Config[:knife][:rackspace_disk_config],


### PR DESCRIPTION
Existing options in a knife config (e.g. 'image' in knife.rb)
would take precedence over the options given on the command line
The resulting api call wouldn't match what the user gave.

As a knife-rackspace user, I want to be able to save time by setting defaults in my knife.rb for rackspace sub-commands. However, I also would like to be able to override them on a case by case basis as needed. Currently this is not possible. Options specified in a knife.rb take precedence over options passed with the sub-command.

My use case is that I set a default image, flavor etc. in my knife.rb for knife ec2. If you want something different, I can specify it along with the knife ec2 server create command. However, with knife rackspace the opposite is true. Any options passed with the create sub-command are ignored if there is a entry in my knife.rb.  The end result is that I try to create a server in rackspace with an AWS AMI and flavor.