### PR TITLE
Add boot from volume, documentation

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -52,6 +52,11 @@ This plugin also has support for authenticating against an alternate API Auth UR
 
     knife[:rackspace_auth_url] = "auth.my-custom-endpoint.com"
 
+This plugin has support for Rackspace's [Boot from Volume](http://www.rackspace.com/knowledge_center/article/boot-a-server-from-a-cloud-block-storage-volume) feature:
+
+    knife[:boot_volume_id] = <UUID>
+
+_If you specify a boot from volume id, you should omit the usual image id parameter._
 
 Different regions can be specified by using the `--rackspace-region` switch or using the `knife[:rackspace_region]` in the knife.rb file. Valid regions include :dfw, :ord, :lon, and :syd.
 
@@ -105,7 +110,7 @@ Secondly, you need to make sure that the image you're using has WinRM pre-config
 Thirdly, you must pass two extra parameters to the knife rackspace create command:
 
     --bootstrap-protocol winrm --distro windows-chef-client-msi
-    
+
 If you have troubles, make sure you add the <tt>-VV</tt> switch for extra verbosity. The <tt>--server-create-timeout </tt> switch may also be your friend, as Windows machines take a long time to build compared to Linux ones.
 
 == knife rackspace server delete

--- a/knife-rackspace.gemspec
+++ b/knife-rackspace.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.add_dependency "knife-windows"
-  s.add_dependency "fog", '>= 1.22'
+  s.add_dependency "fog", '>= 1.24'
   s.add_dependency "chef", ">= 0.10.10"
   s.require_paths = ["lib"]
 

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -483,7 +483,8 @@ class Chef
         msg_pair("Host ID", server.host_id)
         msg_pair("Name", server.name)
         msg_pair("Flavor", server.flavor.name)
-        msg_pair("Image", server.image.name)
+        msg_pair("Image", server.image.name) if server.image
+        msg_pair("Boot Image ID", server.boot_image_id) if server.boot_image_id
         msg_pair("Metadata", server.metadata)
         msg_pair("Public DNS Name", public_dns_name(server))
         msg_pair("Public IP Address", ip_address(server, 'public'))


### PR DESCRIPTION
RE: #91, #95.

Per #91, this adds some documentation on top of the #95 commits providing the needed functionality. The thread in #95 asks for some specs, but we don't really have any specs that test each parameter in knife-rackspace, so there isn't really any established pattern. The project appears to have some functional tests ensuring the right FOG behavior (ensuring particular endpoints), but it does not test most parameters as far as I can tell.