### PR TITLE
Add support for RackconnectV3's Public IP changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,7 @@ deploy:
     secure: YeHeF7cuLuN3lHJQNQ4jpgfhaHGuB861cF6dzoyGPzAi/PO3wmTZfDNG27iI3zCe3CPviDSPiK4v14SQA1Xq3UtvSmeE+zcX/PxYsjNp7EQPn8J6fq2DfjmhYU5ECXnojbTkoh2HIM29YXBjxS8VlSTFDHYx0oV6uMZFgrzSLrI=
   on:
     tags: true
+notifications:
+    irc:
+      - "chat.freenode.net#openstack-chef"
+      - "chat.freenode.net#chef-hacking"

--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -192,7 +192,7 @@ class Chef
       end
 
       def v1_public_ip(server)
-          server.public_ip_address == nil ? "" : server.public_ip_address
+        server.public_ip_address == nil ? "" : server.public_ip_address
       end
 
       def v1_private_ip(server)


### PR DESCRIPTION
This adds the `--rackconnect-v3-network-id` option. It's used like so:

In `knife.rb`
`knife[:rackconnect_v3_network_id] = 'NETGUID'`

On CLI:
`knife rackspace server create -I 112 -f 3 -r 'role[webserver]' -VV --rackconnect-v3-network-id 'NETGUID'`

Cloud servers spun up can be attached to a network as always, but with RackconnectV3, the cloud server needs be added to a network and a Rackconnect API call must be made to create a new public IP address.