### PR TITLE
Guard against nil server image in server create/destroy

### DIFF
--- a/lib/chef/knife/rackspace_network_create.rb
+++ b/lib/chef/knife/rackspace_network_create.rb
@@ -7,7 +7,7 @@ class Chef
       include Knife::RackspaceBase
 
       banner "knife rackspace network create (options)"
-      
+
       option :label,
         :short => "-L LABEL",
         :long => "--label LABEL",
@@ -19,7 +19,7 @@ class Chef
         :long => "--cidr CIDR",
         :description => "CIDR for the network",
         :required => true
-      
+
       def run
         if version_one?
           ui.error "Networks are not supported in v1"

--- a/lib/chef/knife/rackspace_network_delete.rb
+++ b/lib/chef/knife/rackspace_network_delete.rb
@@ -7,7 +7,7 @@ class Chef
       include Knife::RackspaceBase
 
       banner "knife rackspace network delete NETWORK_ID [NETWORK_ID] (options)"
-      
+
       def run
         if version_one?
           ui.error "Networks are not supported in v1"
@@ -22,7 +22,7 @@ class Chef
             msg_pair("Network ID", network.id)
             msg_pair("Label", network.label)
             msg_pair("CIDR", network.cidr)
-            
+
             puts "\n"
             confirm("Do you really want to delete this network")
 

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -451,7 +451,8 @@ class Chef
         msg_pair("Host ID", server.host_id)
         msg_pair("Name", server.name)
         msg_pair("Flavor", server.flavor.name)
-        msg_pair("Image", server.image.name)
+        msg_pair("Image", server.image.name) if server.image
+        msg_pair("Boot Image ID", server.boot_image_id) if server.boot_image_id
         msg_pair("Metadata", server.metadata)
         msg_pair("Public DNS Name", public_dns_name(server))
         msg_pair("Public IP Address", ip_address(server, 'public'))

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -387,8 +387,8 @@ class Chef
 
         # wait for it to be ready to do stuff
         begin
-          server.wait_for(Integer(locate_config_value(:server_create_timeout))) { 
-            print "."; 
+          server.wait_for(Integer(locate_config_value(:server_create_timeout))) {
+            print ".";
             Chef::Log.debug("#{progress}%")
             if rackconnect_wait and rackspace_servicelevel_wait
               Chef::Log.debug("rackconnect_automation_status: #{metadata.all['rackconnect_automation_status']}")
@@ -461,11 +461,11 @@ class Chef
         msg_pair("Environment", config[:environment] || '_default')
         msg_pair("Run List", config[:run_list].join(', '))
       end
-      
+
       def user_data
         file = Chef::Config[:knife][:rackspace_user_data]
         return unless file
-        
+
         begin
           filename = File.expand_path(file)
           content = File.read(filename)

--- a/lib/chef/knife/rackspace_server_delete.rb
+++ b/lib/chef/knife/rackspace_server_delete.rb
@@ -65,8 +65,8 @@ class Chef
             msg_pair("Instance ID", server.id.to_s)
             msg_pair("Host ID", server.host_id)
             msg_pair("Name", server.name)
-            msg_pair("Flavor", server.flavor.name)
-            msg_pair("Image", server.image.name)
+            msg_pair("Flavor", server.flavor.name)            
+            msg_pair("Image", server.image.name) if server.image
             msg_pair("Public IP Address", ip_address(server, 'public'))
             msg_pair("Private IP Address", ip_address(server, 'private'))
 

--- a/lib/chef/knife/rackspace_server_delete.rb
+++ b/lib/chef/knife/rackspace_server_delete.rb
@@ -65,7 +65,7 @@ class Chef
             msg_pair("Instance ID", server.id.to_s)
             msg_pair("Host ID", server.host_id)
             msg_pair("Name", server.name)
-            msg_pair("Flavor", server.flavor.name)            
+            msg_pair("Flavor", server.flavor.name)
             msg_pair("Image", server.image.name) if server.image
             msg_pair("Public IP Address", ip_address(server, 'public'))
             msg_pair("Private IP Address", ip_address(server, 'private'))

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -48,7 +48,7 @@ performance2-15   15 GB Performance        4      15360   40 GB
 performance2-30   30 GB Performance        8      30720   40 GB
 performance2-60   60 GB Performance        16     61440   40 GB
 performance2-90   90 GB Performance        24     92160   40 GB
-"""} 
+"""}
       stdout = ANSI.unansi stdout
       stdout.should match_output(expected_output[api])
     end


### PR DESCRIPTION
This is likely to bite if you are booting a server from a CBS volume instead of an image.

Also, I cleaned some whitespace.