### PR TITLE
Updates for travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
----
 language: ruby
 rvm:
 - 2.2
@@ -6,23 +5,30 @@ rvm:
 - 2.0.0
 env:
   global:
-  - secure: ! 'eEsikE/p2yz7/cFvCN/NOoljxBqjzsTWnKC7iZ+fEGGsyhKVJgWn4AasBusZ
-
+  - secure: |-
+      eEsikE/p2yz7/cFvCN/NOoljxBqjzsTWnKC7iZ+fEGGsyhKVJgWn4AasBusZ
       mhtQcOqwakRulzVc+EZN4pqWHgaMC7SnSwhqRU5u1E+BPI4iWNsu+7rjiXhE
-
-      cJK1vE8YodgsgRDQ6evZVQLkwJpRk0qq2tM2LDqpzvy2MeQJIGc='
-  - secure: ! 'V3ohIIF3I8lD05zTUs2nu+CcIzBYcvt1c1euRJ+SPcAH493b4cPquw1NZNFy
-
+      cJK1vE8YodgsgRDQ6evZVQLkwJpRk0qq2tM2LDqpzvy2MeQJIGc=
+  - secure: |-
+      V3ohIIF3I8lD05zTUs2nu+CcIzBYcvt1c1euRJ+SPcAH493b4cPquw1NZNFy
       WDIW+1qDQi1DXr8C3Yq8bL4+pY66SukHtxyLhx0V26lGUvI8naq3IqageBQK
-
-      pkb2zZwVYO0a5mLEKOI/7omExBVHDxxX9Bw45vCHLKId3Wt21HE='
-  - secure: ! 'OyKQU1muVBijz2/EkLUgBWbwPKG2UqRhIfpB1ZFkfdQ/06+Vaf82ZEQk3DvY
-
+      pkb2zZwVYO0a5mLEKOI/7omExBVHDxxX9Bw45vCHLKId3Wt21HE=
+  - secure: |-
+      OyKQU1muVBijz2/EkLUgBWbwPKG2UqRhIfpB1ZFkfdQ/06+Vaf82ZEQk3DvY
       2lYFrzvSN1yWrKTMU3XES/dPlVlH87LDOrRhNhgW/NeHhC5BzdwrtvBm08RN
-
-      64ACuFG8fch9zIbx2VTkyLV8xsFXPPSaKMbEXrnikLwqnl5M8PQ='
-  - secure: ! 'DoDVG0HwFg2a7Fj72tlxb8KJto+cBEh7J9YQZ35hK2cmeTsBAcZ4oSOUeAFg
-
+      64ACuFG8fch9zIbx2VTkyLV8xsFXPPSaKMbEXrnikLwqnl5M8PQ=
+  - secure: |-
+      DoDVG0HwFg2a7Fj72tlxb8KJto+cBEh7J9YQZ35hK2cmeTsBAcZ4oSOUeAFg
       s2MvBhX0man0zjYPStbL1vcpuS1Ecea3kGzefG0lYhHAzvK7wqqRqhKNFsnd
-
-      FPEVgZrcj3/Lc7mlkbigZouDM7BJLQbMGOv/KOS6f3nYzIhkOfE='
+      FPEVgZrcj3/Lc7mlkbigZouDM7BJLQbMGOv/KOS6f3nYzIhkOfE=
+deploy:
+  provider: rubygems
+  api_key:
+    secure: YeHeF7cuLuN3lHJQNQ4jpgfhaHGuB861cF6dzoyGPzAi/PO3wmTZfDNG27iI3zCe3CPviDSPiK4v14SQA1Xq3UtvSmeE+zcX/PxYsjNp7EQPn8J6fq2DfjmhYU5ECXnojbTkoh2HIM29YXBjxS8VlSTFDHYx0oV6uMZFgrzSLrI=
+  on:
+    tags: true
+notifications:
+    irc:
+      - "chat.freenode.net#openstack-chef"
+      - "chat.freenode.net#chef-hacking"
+      - "chat.freenode.net#rackspace"

--- a/knife-rackspace.gemspec
+++ b/knife-rackspace.gemspec
@@ -5,10 +5,11 @@ require "knife-rackspace/version"
 Gem::Specification.new do |s|
   s.name        = "knife-rackspace"
   s.version     = Knife::Rackspace::VERSION
+  s.version = "#{s.version}-alpha-#{ENV['TRAVIS_BUILD_NUMBER']}" if ENV['TRAVIS']
   s.has_rdoc = true
-  s.authors     = ["Adam Jacob","Seth Chisamore", "Matt Ray"]
-  s.email       = ["adam@opscode.com","schisamo@opscode.com", "matt@opscode.com"]
-  s.homepage = "http://wiki.opscode.com/display/chef"
+  s.authors     = ["Adam Jacob","Seth Chisamore", "Matt Ray","Rackspace Developers","JJ Asghar"]
+  s.email       = ["adam@chef.io","schisamo@chef.io", "matt@chef.io","jj@chef.io"]
+  s.homepage = "https://docs.chef.io/plugin_knife_rackspace.html"
   s.summary = "Rackspace Support for Chef's Knife Command"
   s.description = s.summary
   s.extra_rdoc_files = ["README.rdoc", "LICENSE" ]


### PR DESCRIPTION
- Update for travis.yml to release to ruby gems
- Updated the gemspec with some out of date information
- Travis announcing releases to #rackspace, #chef-hacking, #openstack-chef on freenode.