### PR TITLE
Swap out specific config accessors for "locate_config_value"

### DIFF
--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -77,14 +77,17 @@ class Chef
       def connection
         Chef::Log.debug("version #{Chef::Config[:knife][:rackspace_version]} (config)")
         Chef::Log.debug("version #{config[:rackspace_version]} (cli)")
-        Chef::Log.debug("rackspace_api_key #{Chef::Config[:knife][:rackspace_api_key]}")
-        Chef::Log.debug("rackspace_username #{Chef::Config[:knife][:rackspace_username]}")
-        Chef::Log.debug("rackspace_api_username #{Chef::Config[:knife][:rackspace_api_username]}")
-        Chef::Log.debug("rackspace_auth_url #{Chef::Config[:knife][:rackspace_auth_url]}")
-        Chef::Log.debug("rackspace_auth_url #{config[:rackspace_api_auth_url]}")
+        Chef::Log.debug("rackspace_api_key #{Chef::Config[:knife][:rackspace_api_key]} (config)")
+        Chef::Log.debug("rackspace_api_key #{config[:rackspace_api_key]} (cli)")
+        Chef::Log.debug("rackspace_username #{Chef::Config[:knife][:rackspace_username]} (config)")
+        Chef::Log.debug("rackspace_username #{config[:rackspace_username]} (cli)")
+        Chef::Log.debug("rackspace_api_username #{Chef::Config[:knife][:rackspace_api_username]} (config)")
+        Chef::Log.debug("rackspace_api_username #{config[:rackspace_api_username]} (cli)")
+        Chef::Log.debug("rackspace_auth_url #{Chef::Config[:knife][:rackspace_auth_url]} (config)")
+        Chef::Log.debug("rackspace_auth_url #{config[:rackspace_api_auth_url]} (cli)")
         Chef::Log.debug("rackspace_auth_url #{auth_endpoint} (using)")
-        Chef::Log.debug("rackspace_region #{Chef::Config[:knife][:rackspace_region]}")
-        Chef::Log.debug("rackspace_region #{config[:rackspace_region]}")
+        Chef::Log.debug("rackspace_region #{Chef::Config[:knife][:rackspace_region]} (config)")
+        Chef::Log.debug("rackspace_region #{config[:rackspace_region]} (cli)")
 
         if version_one?
           Chef::Log.debug("rackspace v1")
@@ -105,7 +108,7 @@ class Chef
       end
 
       def region_warning_for_v1
-        if Chef::Config[:knife][:rackspace_region] || config[:rackspace_region]
+        if locate_config_value(:rackspace_region)
           Chef::Log.warn("Ignoring the rackspace_region parameter as it is only supported for Next Gen Cloud Servers (v2)")
         end
       end
@@ -116,10 +119,21 @@ class Chef
           exit 1
         end
 
+        username =  locate_config_value(:rackspace_username) || locate_config_value(:rackspace_api_username)
+        unless username
+          ui.error "Please specify an api username via the command line using the --rackspace-username switch or add a knife[:rackspace_username] = USERNAME to your knife file."
+          exit 1
+        end
+
+        unless locate_config_value(:rackspace_api_key)
+          ui.error "Please specify an api key via the command line using the --rackspace-api-key switch or add a knife[:rackspace_api_key] = USERNAME to your knife file."
+          exit 1
+        end
+
         hash = options.merge({
           :provider => 'Rackspace',
-          :rackspace_api_key => Chef::Config[:knife][:rackspace_api_key],
-          :rackspace_username => (Chef::Config[:knife][:rackspace_username] || Chef::Config[:knife][:rackspace_api_username]),
+          :rackspace_api_key => locate_config_value(:rackspace_api_key),
+          :rackspace_username => username,
           :rackspace_auth_url => auth_endpoint,
           :rackspace_region => locate_config_value(:rackspace_region)
         })

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -106,7 +106,8 @@ class Chef
 
       option :prerelease,
         :long => "--prerelease",
-        :description => "Install the pre-release chef gems"
+        :description => "Install the pre-release chef gems",
+        :default => false
 
       option :bootstrap_version,
         :long => "--bootstrap-version VERSION",
@@ -286,9 +287,9 @@ class Chef
       end
 
       def tcp_test_ssh(server, bootstrap_ip)
-        return true unless config[:tcp_test_ssh] != nil
+        return true unless locate_config_value(:tcp_test_ssh) != nil
 
-        limit = Chef::Config[:knife][:retry_ssh_limit].to_i
+        limit = locate_config_value(:retry_ssh_limit).to_i
         count = 0
 
         begin
@@ -301,7 +302,7 @@ class Chef
 
           if count <= limit
             print '.'
-            sleep config[:retry_ssh_every].to_i
+            sleep locate_config_value(:retry_ssh_every).to_i
             tcp_test_ssh(server, bootstrap_ip)
           else
             ui.error "Unable to SSH into #{bootstrap_ip}"
@@ -372,18 +373,18 @@ class Chef
         $stdout.sync = true
 
         server_create_options = {
-          :metadata => Chef::Config[:knife][:rackspace_metadata],
-          :disk_config => Chef::Config[:knife][:rackspace_disk_config],
+          :metadata => locate_config_value(:rackspace_metadata),
+          :disk_config => locate_config_value(:rackspace_disk_config),
           :user_data => user_data,
           :config_drive => locate_config_value(:rackspace_config_drive) || false,
           :personality => files,
-          :key_name => Chef::Config[:knife][:rackspace_ssh_keypair],
+          :key_name => locate_config_value(:rackspace_ssh_keypair),
           :name => get_node_name(config[:chef_node_name] || config[:server_name]),
-          :networks => get_networks(Chef::Config[:knife][:rackspace_networks], Chef::Config[:knife][:rackconnect_v3_network_id]),
+          :networks => get_networks(locate_config_value(:rackspace_networks), locate_config_value(:rackconnect_v3_network_id)),
         }
 
         # Maybe deprecate this option at some point
-        config[:bootstrap_network] = 'private' if config[:private_network]
+        config[:bootstrap_network] = 'private' if locate_config_value(:private_network)
 
         flavor_id = locate_config_value(:flavor)
         flavor = connection.flavors.get(flavor_id)
@@ -401,15 +402,15 @@ class Chef
         # swap out the image_id argument with the boot_image_id argument.
         if flavor.disk == 0
           server_create_options[:image_id] = ''
-          server_create_options[:boot_volume_id] = Chef::Config[:knife][:boot_volume_id]
-          server_create_options[:boot_image_id] = Chef::Config[:knife][:image]
+          server_create_options[:boot_volume_id] = locate_config_value(:boot_volume_id)
+          server_create_options[:boot_image_id] = locate_config_value(:image)
 
           if server_create_options[:boot_image_id] && server_create_options[:boot_volume_id]
             ui.error('Please specify exactly one of --boot-volume-id (-B) and --image (-I)')
             exit 1
           end
         else
-          server_create_options[:image_id] = Chef::Config[:knife][:image]
+          server_create_options[:image_id] = locate_config_value(:image)
 
           if !server_create_options[:image_id]
             ui.error('Please specify an Image ID for the server with --image (-I)')
@@ -429,8 +430,8 @@ class Chef
           server.save(:networks => server_create_options[:networks])
         end
 
-        rackconnect_wait = Chef::Config[:knife][:rackconnect_wait] || config[:rackconnect_wait]
-        rackspace_servicelevel_wait = Chef::Config[:knife][:rackspace_servicelevel_wait] || config[:rackspace_servicelevel_wait]
+        rackconnect_wait = locate_config_value(:rackconnect_wait)
+        rackspace_servicelevel_wait = locate_config_value(:rackspace_servicelevel_wait)
 
         msg_pair("Instance ID", server.id)
         msg_pair("Host ID", server.host_id)
@@ -440,11 +441,11 @@ class Chef
         msg_pair("Boot Image ID", server.boot_image_id) if server.boot_image_id
         msg_pair("Metadata", server.metadata.all)
         msg_pair("ConfigDrive", server.config_drive)
-        msg_pair("UserData", Chef::Config[:knife][:rackspace_user_data])
+        msg_pair("UserData", locate_config_value(:rackspace_user_data))
         msg_pair("RackConnect Wait", rackconnect_wait ? 'yes' : 'no')
-        msg_pair("RackConnect V3", Chef::Config[:knife][:rackconnect_v3_network_id] ? 'yes' : 'no')
+        msg_pair("RackConnect V3", locate_config_value(:rackconnect_v3_network_id) ? 'yes' : 'no')
         msg_pair("ServiceLevel Wait", rackspace_servicelevel_wait ? 'yes' : 'no')
-        msg_pair("SSH Key", Chef::Config[:knife][:rackspace_ssh_keypair])
+        msg_pair("SSH Key", locate_config_value(:rackspace_ssh_keypair))
 
         # wait for it to be ready to do stuff
         begin
@@ -480,7 +481,7 @@ class Chef
 
         puts("\n")
 
-        if Chef::Config[:knife][:rackconnect_v3_network_id]
+        if locate_config_value(:rackconnect_v3_network_id)
           print "\n#{ui.color("Setting up RackconnectV3 network and IPs", :magenta)}"
           setup_rackconnect_network!(server)
           while server.ipv4_address == ""
@@ -489,8 +490,8 @@ class Chef
           end
         end
 
-        if server_create_options[:networks] && Chef::Config[:knife][:rackspace_networks]
-          msg_pair("Networks", Chef::Config[:knife][:rackspace_networks].sort.join(', '))
+        if server_create_options[:networks] && locate_config_value(:rackspace_networks)
+          msg_pair("Networks", locate_config_value(:rackspace_networks).sort.join(', '))
         end
 
         msg_pair("Public DNS Name", public_dns_name(server))
@@ -499,7 +500,7 @@ class Chef
         msg_pair("Password", server.password)
         msg_pair("Metadata", server.metadata.all)
 
-        bootstrap_ip_address = ip_address(server, config[:bootstrap_network])
+        bootstrap_ip_address = ip_address(server, locate_config_value(:bootstrap_network))
 
         Chef::Log.debug("Bootstrap IP Address #{bootstrap_ip_address}")
         if bootstrap_ip_address.nil?
@@ -554,7 +555,7 @@ class Chef
       end
 
       def user_data
-        file = Chef::Config[:knife][:rackspace_user_data]
+        file = locate_config_value(:rackspace_user_data)
         return unless file
 
         begin
@@ -570,16 +571,16 @@ class Chef
       def bootstrap_for_node(server, bootstrap_ip_address)
         bootstrap = Chef::Knife::Bootstrap.new
         bootstrap.name_args = [bootstrap_ip_address]
-        bootstrap.config[:ssh_user] = config[:ssh_user] || "root"
+        bootstrap.config[:ssh_user] = locate_config_value(:ssh_user) || "root"
         bootstrap.config[:ssh_password] = server.password
-        bootstrap.config[:ssh_port] = config[:ssh_port] || Chef::Config[:knife][:ssh_port]
-        bootstrap.config[:identity_file] = config[:identity_file]
-        bootstrap.config[:host_key_verify] = config[:host_key_verify]
-        bootstrap.config[:bootstrap_vault_file] = config[:bootstrap_vault_file] if config[:bootstrap_vault_file]
-        bootstrap.config[:bootstrap_vault_json] = config[:bootstrap_vault_json] if config[:bootstrap_vault_json]
-        bootstrap.config[:bootstrap_vault_item] = config[:bootstrap_vault_item] if config[:bootstrap_vault_item]
+        bootstrap.config[:ssh_port] = locate_config_value(:ssh_port)
+        bootstrap.config[:identity_file] = locate_config_value(:identity_file)
+        bootstrap.config[:host_key_verify] = locate_config_value(:host_key_verify)
+        bootstrap.config[:bootstrap_vault_file] = locate_config_value(:bootstrap_vault_file) if locate_config_value(:bootstrap_vault_file)
+        bootstrap.config[:bootstrap_vault_json] = locate_config_value(:bootstrap_vault_json) if locate_config_value(:bootstrap_vault_json)
+        bootstrap.config[:bootstrap_vault_item] = locate_config_value(:bootstrap_vault_item) if locate_config_value(:bootstrap_vault_item)
         # bootstrap will run as root...sudo (by default) also messes up Ohai on CentOS boxes
-        bootstrap.config[:use_sudo] = true unless config[:ssh_user] == 'root'
+        bootstrap.config[:use_sudo] = true unless locate_config_value(:ssh_user) == 'root'
         bootstrap.config[:distro] = locate_config_value(:distro)  || 'chef-full'
         bootstrap_common_params(bootstrap, server)
       end
@@ -592,13 +593,14 @@ class Chef
         else
           bootstrap.config[:chef_node_name] = config[:chef_node_name] || server.name
         end
-        bootstrap.config[:prerelease] = config[:prerelease]
+        bootstrap.config[:prerelease] = locate_config_value(:prerelease)
         bootstrap.config[:bootstrap_version] = locate_config_value(:bootstrap_version)
         bootstrap.config[:template_file] = locate_config_value(:template_file)
-        bootstrap.config[:first_boot_attributes] = config[:first_boot_attributes]
+        bootstrap.config[:first_boot_attributes] = locate_config_value(:first_boot_attributes)
         bootstrap.config[:bootstrap_proxy] = locate_config_value(:bootstrap_proxy)
-        bootstrap.config[:encrypted_data_bag_secret] = config[:encrypted_data_bag_secret]
-        bootstrap.config[:encrypted_data_bag_secret_file] = config[:encrypted_data_bag_secret_file]
+#        TODO: Remove dead code. There's no command line parameter for these two.
+#        bootstrap.config[:encrypted_data_bag_secret] = config[:encrypted_data_bag_secret]
+#        bootstrap.config[:encrypted_data_bag_secret_file] = config[:encrypted_data_bag_secret_file]
         bootstrap.config[:secret] = locate_config_value(:secret)
         bootstrap.config[:secret_file] = locate_config_value(:secret_file)  || ""
 
@@ -629,16 +631,16 @@ class Chef
     def get_networks(names, rackconnect3=false)
       names = Array(names)
 
-      if(Chef::Config[:knife][:rackspace_version] == 'v2')
-        if rackconnect3
-          nets = [Chef::Config[:knife][:rackconnect_v3_network_id]]
-        elsif config[:default_networks]
-          nets = [
+      if(locate_config_value(:rackspace_version) == 'v2')
+        nets = if rackconnect3
+          [locate_config_value(:rackconnect_v3_network_id)]
+        elsif locate_config_value(:default_networks)
+          [
             '00000000-0000-0000-0000-000000000000',
             '11111111-1111-1111-1111-111111111111'
           ]
         else
-          nets  = []
+          []
         end
 
         available_networks = connection.networks.all

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -144,8 +144,8 @@ class Chef
         :short => "-M JSON",
         :long => "--rackspace-metadata JSON",
         :description => "JSON string version of metadata hash to be supplied with the server create call",
-        :proc => Proc.new { |m| Chef::Config[:knife][:rackspace_metadata] = JSON.parse(m) },
-        :default => ""
+        :proc => lambda { |m| JSON.parse(m) },
+        :default => {}
 
       option :rackconnect_wait,
         :long => "--rackconnect-wait",
@@ -233,9 +233,8 @@ class Chef
 
       option :rackspace_disk_config,
         :long => "--rackspace-disk-config DISKCONFIG",
-        :description => "Specify if want to manage your own disk partitioning scheme (AUTO or MANUAL), default is AUTO",
-        :proc => Proc.new { |k| Chef::Config[:knife][:rackspace_disk_config] = k },
-        :default => "AUTO"
+        :description => "Specify if want to manage your own disk partitioning scheme (AUTO or MANUAL)",
+        :proc => Proc.new { |k| Chef::Config[:knife][:rackspace_disk_config] = k }
 
       option :rackspace_config_drive,
         :long => "--rackspace_config_drive CONFIGDRIVE",

--- a/lib/knife-rackspace/version.rb
+++ b/lib/knife-rackspace/version.rb
@@ -1,6 +1,6 @@
 module Knife
   module Rackspace
-    VERSION = '0.11.0'
+    VERSION = '0.11.1'
     MAJOR, MINOR, TINY = VERSION.split('.')
   end
 end


### PR DESCRIPTION
This pull request comes from my experience in trying to wrap the server creation task with my own knife plugin. When trying to set parameters for a call into this task, I had to keep consulting the code to see if the places where the values were used were calling from the `config` hash or from the global `Chef::Config[:knife]`. This swaps (almost) all of the accessors on these hashes to the already wonderful `locate_config_value` function in `rackspace_base.rb`.

It's worth noting that accessors for `environment`, `run_list`, `chef_node_name`, and `server_name` still use the config hash accessor. For `environment`, this is because this is a built-in command line argument for knife, which complicates how it can be accessed and modified. For the other three, it is because it didn't seem like there would be reasonable defaults to put into the `knife.rb` config file (although, looking back now, I could see someone making a case for being able to set `run_list` like this).

I have one outstanding question: Line 601-603 specify two variables which are, as far as I saw, not set anywhere and do not have command line options for setting them. Should they be removed, should options be added for them, or should they be left as they were?