### PR TITLE
Add boot_volume_size option to -B in `knife rackspace server create`

### DIFF
--- a/knife-rackspace.gemspec
+++ b/knife-rackspace.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.add_dependency "knife-windows"
-  s.add_dependency "fog", '>= 1.24'
+  s.add_dependency "fog", '>= 1.35'
   s.add_dependency "chef", ">= 0.10.10"
   s.require_paths = ["lib"]
 

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -54,6 +54,12 @@ class Chef
         :description => "The image of the server",
         :proc => Proc.new { |i| Chef::Config[:knife][:image] = i.to_s }
 
+      option :boot_volume_size,
+        :long => "--boot-volume-size GB",
+        :description => "The size of the CBS to use as the server's boot device",
+        :proc => Proc.new { |i| Chef::Config[:knife][:boot_volume_size] = i.to_s },
+        :default => 100
+
       option :boot_volume_id,
         :short => "-B BOOT_VOLUME_ID",
         :long => "--boot-volume-id UUID",
@@ -403,9 +409,10 @@ class Chef
           server_create_options[:image_id] = ''
           server_create_options[:boot_volume_id] = locate_config_value(:boot_volume_id)
           server_create_options[:boot_image_id] = locate_config_value(:image)
+          server_create_options[:boot_volume_size] = locate_config_value(:boot_volume_size)
 
           if server_create_options[:boot_image_id] && server_create_options[:boot_volume_id]
-            ui.error('Please specify exactly one of --boot-volume-id (-B) and --image (-I)')
+            ui.error('Please specify either --boot-volume-id (-B) or --image (-I)')
             exit 1
           end
         else

--- a/lib/chef/knife/rackspace_server_delete.rb
+++ b/lib/chef/knife/rackspace_server_delete.rb
@@ -67,6 +67,7 @@ class Chef
             msg_pair("Name", server.name)
             msg_pair("Flavor", server.flavor.name)
             msg_pair("Image", server.image.name) if server.image
+            msg_pair("Boot Image ID", server.boot_image_id) if server.boot_image_id
             msg_pair("Public IP Address", ip_address(server, 'public'))
             msg_pair("Private IP Address", ip_address(server, 'private'))
 


### PR DESCRIPTION
When using the -B option with `knife rackspace server create`, the size
of the created volume is hardcoded to 100GB.

In order to specify the volume size, I added the boot_volume_size option
to fog's create_server call (merged in fog 1.35).
This commit leverages this new fog option and allows to use smaller
volumes (miminum 50GB) as well as larger ones.

This commit also clarifies the wording of one misleading error message.