### PR TITLE
Use fog/rackspace instead of fog

### DIFF
--- a/knife-rackspace.gemspec
+++ b/knife-rackspace.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.add_dependency "knife-windows"
-  s.add_dependency "fog", ">= 1.35"
+  s.add_dependency "fog-rackspace", ">= 0.1"
   s.add_dependency "chef", ">= 12.0"
   s.require_paths = ["lib"]
 end

--- a/lib/chef/knife/rackspace_base.rb
+++ b/lib/chef/knife/rackspace_base.rb
@@ -17,7 +17,7 @@
 #
 
 require "chef/knife"
-require "fog"
+require "fog/rackspace"
 
 class Chef
   class Knife
@@ -30,7 +30,7 @@ class Chef
         includer.class_eval do
 
           deps do
-            require "fog"
+            require "fog/rackspace"
             require "net/ssh/multi"
             require "readline"
             require "chef/json_compat"

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -29,7 +29,7 @@ class Chef
       include Chef::Knife::WinrmBase
 
       deps do
-        require "fog"
+        require "fog/rackspace"
         require "readline"
         require "chef/json_compat"
         require "chef/knife/bootstrap"


### PR DESCRIPTION
Fog is the old school monolithic gem which has been replaced. This gem
loads MUCH faster and brings in fewer deps, which keeps installs nice
and small

Signed-off-by: Tim Smith <tsmith@chef.io>