### PR TITLE
Fix em-winrm dependencies and close TCP sockets

### DIFF
--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -258,10 +258,15 @@ class Chef
         :proc => Proc.new { |v| Chef::Config[:knife][:rackspace_ssh_keypair] = v },
         :default => nil
 
+      option :secret,
+        :long => "--secret",
+        :description => "The secret key to us to encrypt data bag item values",
+        :proc => lambda { |s| Chef::Config[:knife][:secret] = s }
+
       option :secret_file,
         :long => "--secret-file SECRET_FILE",
         :description => "A file containing the secret key to use to encrypt data bag item values",
-        :proc => Proc.new { |sf| Chef::Config[:knife][:secret_file] = sf }
+        :proc => lambda { |sf| Chef::Config[:knife][:secret_file] = sf }
 
       option :bootstrap_vault_file,
         :long        => "--bootstrap-vault-file VAULT_FILE",
@@ -284,10 +289,9 @@ class Chef
 
       def load_winrm_deps
         require "winrm"
-        require "em-winrm"
+        require "chef/knife/winrm"
         require "chef/knife/bootstrap_windows_winrm"
         require "chef/knife/core/windows_bootstrap_context"
-        require "chef/knife/winrm"
       end
 
       def tcp_test_ssh(server, bootstrap_ip)
@@ -605,7 +609,7 @@ class Chef
 #        bootstrap.config[:encrypted_data_bag_secret] = config[:encrypted_data_bag_secret]
 #        bootstrap.config[:encrypted_data_bag_secret_file] = config[:encrypted_data_bag_secret_file]
         bootstrap.config[:secret] = locate_config_value(:secret)
-        bootstrap.config[:secret_file] = locate_config_value(:secret_file) || ""
+        bootstrap.config[:secret_file] = locate_config_value(:secret_file)
 
         Chef::Config[:knife][:hints] ||= {}
         Chef::Config[:knife][:hints]["rackspace"] ||= {}

--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -355,8 +355,9 @@ class Chef
       end
 
       def tcp_test_winrm(hostname, port)
-        TCPSocket.new(hostname, port)
-        return true
+        tcp_socket = TCPSocket.new(hostname, port)
+        yield
+        true
       rescue SocketError
         sleep 2
         false
@@ -373,6 +374,7 @@ class Chef
       rescue Errno::ENETUNREACH
         sleep 2
         false
+        tcp_socket && tcp_socket.close
       end
 
       def run


### PR DESCRIPTION
Added missing option for -secret
Fixed em-winrm dependencies
Closed TCP socket at the end of the request.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the
    best of my knowledge, is covered under an appropriate open
    source license and I have the right under that license to   
    submit that work with modifications, whether created in whole
    or in part by me, under the same open source license (unless
    I am permitted to submit under a different license), as
    Indicated in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including
    all personal information I submit with it, including my
    sign-off) is maintained indefinitely and may be redistributed
    consistent with this project or the open source license(s)
    involved.