### PR TITLE
Removed 'yield' that broke winrm bootstrapping.

### DIFF
--- a/lib/chef/knife/rackspace_server_create.rb
+++ b/lib/chef/knife/rackspace_server_create.rb
@@ -356,7 +356,6 @@ class Chef
 
       def tcp_test_winrm(hostname, port)
         tcp_socket = TCPSocket.new(hostname, port)
-        yield
         true
       rescue SocketError
         sleep 2


### PR DESCRIPTION
Signed-off-by: martin-stevens <martin.stevens@salesforce.com>